### PR TITLE
allow to build the libraries from command line

### DIFF
--- a/Source/Krypton Components/ComponentFactory.Krypton.Docking/ComponentFactory.Krypton.Docking 2019.csproj
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Docking/ComponentFactory.Krypton.Docking 2019.csproj
@@ -27,6 +27,11 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <PackageId>KryptonToolkitSuiteDockingModule</PackageId>
+  </PropertyGroup>
+
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>

--- a/Source/Krypton Components/ComponentFactory.Krypton.Navigator/ComponentFactory.Krypton.Navigator 2019.csproj
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Navigator/ComponentFactory.Krypton.Navigator 2019.csproj
@@ -28,9 +28,15 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <PackageId>KryptonToolkitSuiteNavigatorModule</PackageId>
+    <Description>A update to Component factory's krypton toolkit to support .NET Core and the latest .NET 4.x framework. This is the navigator module.</Description>
+  </PropertyGroup>
+
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-  </PropertyGroup>
+  </PropertyGroup>  
   <ItemGroup>
     <Compile Include="..\ComponentFactory.Krypton.Toolkit\General\GlobalSuppressions.cs" Link="General\GlobalSuppressions.cs" />
     <Compile Include="..\ComponentFactory.Krypton.Toolkit\General\PlatformInvoke.cs">

--- a/Source/Krypton Components/ComponentFactory.Krypton.Ribbon/ComponentFactory.Krypton.Ribbon 2019.csproj
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Ribbon/ComponentFactory.Krypton.Ribbon 2019.csproj
@@ -26,6 +26,12 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <PackageId>KryptonToolkitSuiteRibbonModule</PackageId>
+    <Description>A update to Component factory's krypton toolkit to support .NET Core and the latest .NET 4.x framework. This is the ribbon module.</Description>
+  </PropertyGroup>
+
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>

--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/ComponentFactory.Krypton.Toolkit 2019.csproj
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/ComponentFactory.Krypton.Toolkit 2019.csproj
@@ -28,6 +28,12 @@
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <UseWindowsForms>true</UseWindowsForms>
     </PropertyGroup>
+
+    <PropertyGroup>
+        <PackageId>KryptonToolkitSuiteCoreModule</PackageId>
+        <Description>A update to Component factory's krypton toolkit to support .NET Core and the latest .NET 4.x framework. This is the core module.</Description>
+    </PropertyGroup>
+  
     <PropertyGroup>
         <ApplicationManifest>app.manifest</ApplicationManifest>
     </PropertyGroup>

--- a/Source/Krypton Components/ComponentFactory.Krypton.Workspace/ComponentFactory.Krypton.Workspace 2019.csproj
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Workspace/ComponentFactory.Krypton.Workspace 2019.csproj
@@ -26,6 +26,12 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <PackageId>KryptonToolkitSuiteWorkspaceModule</PackageId>
+    <Description>A update to Component factory's krypton toolkit to support .NET Core and the latest .NET 4.x framework. This is the workspace module.</Description>
+  </PropertyGroup>
+
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>

--- a/Source/Krypton Components/Directory.Build.props
+++ b/Source/Krypton Components/Directory.Build.props
@@ -1,0 +1,15 @@
+<Project>
+  <PropertyGroup>    
+    <!-- common package data -->
+    <PackageProjectUrl>https://github.com/Wagnerp/Krypton-Toolkit-Suite-NET-Core</PackageProjectUrl>
+	<PackageIcon>Square Design 64 x 64 New Green.png</PackageIcon>
+	<Authors>Peter William Wagner &amp; Simon Coghlan</Authors>
+	<PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
+	<PackageTags>Krypton ComponentFactory WinForms Themes Controls DataGrid Ribbon Workspace Tabs .Net Toolkit Core</PackageTags>
+	<PackageReleaseNotes>Get updates here: https://github.com/Wagnerp/Krypton-Toolkit-Suite-NET-Core</PackageReleaseNotes>
+  </PropertyGroup>
+  
+  <ItemGroup>
+	<None Include="../../../Assets/PNG/Square Design/Main Icon/64 x 64/Square Design 64 x 64 New Green.png" Link="Icon.png" Pack="true" PackagePath="" />
+  </ItemGroup>
+</Project>

--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,33 @@
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin" goto vs16prev
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin" goto vs16ent
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin" goto vs16pro
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin" goto vs16com
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" goto vs16build
+
+echo "Unable to detect suitable environment. Check if VS 2019 is installed."
+exit 1
+
+:vs16prev
+set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin
+goto build
+
+:vs16ent
+set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin
+goto build
+
+:vs16pro
+set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin
+goto build
+
+:vs16com
+set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin
+goto build
+
+:vs16build
+set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin
+goto build
+
+:build
+set targets=Build
+if not "%~1" == "" set targets=%~1
+"%msbuildpath%\msbuild.exe" /t:%targets% build.proj /fl /flp:logfile=build.log

--- a/build.proj
+++ b/build.proj
@@ -1,0 +1,21 @@
+<Project>
+	<PropertyGroup>
+		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
+		<Configuration>Release</Configuration>
+		<Version Condition="'$(Version)' == ''">5.490.2116</Version>
+	</PropertyGroup>
+	
+	<Target Name="Build">
+		<ItemGroup>
+			<Projects Include="$(RootFolder)\Source\Krypton Components\ComponentFactory.Krypton.*\*.csproj" />
+		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration)" />
+	</Target>
+	
+	<Target Name="Pack">
+		<ItemGroup>
+			<Projects Include="$(RootFolder)\Source\Krypton Components\ComponentFactory.Krypton.*\*.csproj" />
+		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);Version=$(Version)" Targets="Pack" />
+	</Target>
+</Project>


### PR DESCRIPTION
It requires visual studio 2019 installed on the developer machine.

`build.cmd` will build all 5 libraries on release mode. This command is a shortcut to `msbuild.exe build.proj`

`build.cmd pack` will create all 5 packages in `bin\release` directory. This command is a shortcut to `msbuild.exe build.proj /t:Pack`

Note: the current core package is 14mb because of the multiple TFM specified. When #4 is merged, the package size will be greatly reduced.