### PR TITLE
change TFMs and package format

### DIFF
--- a/Source/Krypton Components/ComponentFactory.Krypton.Docking/Krypton.Docking 2019.csproj
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Docking/Krypton.Docking 2019.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFrameworks>net40;net45;net451;net452;net46;net461;net462;net47;net471;net472;net48;netcoreapp3.1</TargetFrameworks>
-      <LangVersion>8.0</LangVersion>
-      <OutputType>Library</OutputType>
+    <TargetFrameworks>net45;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TFMs)' == 'all'">net40;net45;net451;net452;net46;net461;net462;net47;net471;net472;net48;netcoreapp3.1</TargetFrameworks>
+    <LangVersion>8.0</LangVersion>
+    <OutputType>Library</OutputType>
     <RootNamespace>ComponentFactory.Krypton.Docking</RootNamespace>
     <AssemblyName>Krypton.Docking</AssemblyName>
     <StartupObject></StartupObject>
@@ -13,7 +14,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PackageId>KryptonToolkitSuiteDockingModule</PackageId>
+    <PackageId>Krypton.Docking</PackageId>
+    <Description>A update to Component factory's krypton toolkit to support .NET Core and the latest .NET 4.x framework. This is the docking module.</Description>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -48,7 +50,7 @@
     <ProjectReference Include="..\ComponentFactory.Krypton.Toolkit\Krypton.Toolkit 2019.csproj" />
     <ProjectReference Include="..\ComponentFactory.Krypton.Workspace\Krypton.Workspace 2019.csproj" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
     <Reference Include="System.Design" />
   </ItemGroup>
   <PropertyGroup>

--- a/Source/Krypton Components/ComponentFactory.Krypton.Navigator/Krypton.Navigator 2019.csproj
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Navigator/Krypton.Navigator 2019.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFrameworks>net40;net45;net451;net452;net46;net461;net462;net47;net471;net472;net48;netcoreapp3.1</TargetFrameworks>
-      <LangVersion>8.0</LangVersion>
+    <TargetFrameworks>net45;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TFMs)' == 'all'">net40;net45;net451;net452;net46;net461;net462;net47;net471;net472;net48;netcoreapp3.1</TargetFrameworks>
+    <LangVersion>8.0</LangVersion>
     <OutputType>Library</OutputType>
     <RootNamespace>ComponentFactory.Krypton.Navigator</RootNamespace>
     <AssemblyName>Krypton.Navigator</AssemblyName>
@@ -13,7 +14,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PackageId>KryptonToolkitSuiteNavigatorModule</PackageId>
+    <PackageId>Krypton.Navigator</PackageId>
     <Description>A update to Component factory's krypton toolkit to support .NET Core and the latest .NET 4.x framework. This is the navigator module.</Description>
   </PropertyGroup>
 
@@ -62,7 +63,7 @@
   <ItemGroup>
     <ProjectReference Include="..\ComponentFactory.Krypton.Toolkit\Krypton.Toolkit 2019.csproj" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
     <Reference Include="System.Design" />
   </ItemGroup>
   <PropertyGroup>

--- a/Source/Krypton Components/ComponentFactory.Krypton.Ribbon/Krypton.Ribbon 2019.csproj
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Ribbon/Krypton.Ribbon 2019.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFrameworks>net40;net45;net451;net452;net46;net461;net462;net47;net471;net472;net48;netcoreapp3.1</TargetFrameworks>
-      <LangVersion>8.0</LangVersion>
+    <TargetFrameworks>net45;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TFMs)' == 'all'">net40;net45;net451;net452;net46;net461;net462;net47;net471;net472;net48;netcoreapp3.1</TargetFrameworks>
+    <LangVersion>8.0</LangVersion>
     <OutputType>Library</OutputType>
     <RootNamespace>ComponentFactory.Krypton.Ribbon</RootNamespace>
     <AssemblyName>Krypton.Ribbon</AssemblyName>
@@ -12,7 +13,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PackageId>KryptonToolkitSuiteRibbonModule</PackageId>
+    <PackageId>Krypton.Ribbon</PackageId>
     <Description>A update to Component factory's krypton toolkit to support .NET Core and the latest .NET 4.x framework. This is the ribbon module.</Description>
   </PropertyGroup>
 
@@ -87,7 +88,7 @@
   <ItemGroup>
     <ProjectReference Include="..\ComponentFactory.Krypton.Toolkit\Krypton.Toolkit 2019.csproj" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
     <Reference Include="System.Design" />
   </ItemGroup>
   <PropertyGroup>

--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Krypton.Toolkit 2019.csproj
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Krypton.Toolkit 2019.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
     <PropertyGroup>
-        <TargetFrameworks>net40;net45;net451;net452;net46;net461;net462;net47;net471;net472;net48;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net45;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks Condition="'$(TFMs)' == 'all'">net40;net45;net451;net452;net46;net461;net462;net47;net471;net472;net48;netcoreapp3.1</TargetFrameworks>
         <LangVersion>8.0</LangVersion>
         <OutputType>Library</OutputType>
         <RootNamespace>ComponentFactory.Krypton.Toolkit</RootNamespace>
@@ -13,7 +14,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <PackageId>KryptonToolkitSuiteCoreModule</PackageId>
+        <PackageId>Krypton.Toolkit</PackageId>
         <Description>A update to Component factory's krypton toolkit to support .NET Core and the latest .NET 4.x framework. This is the core module.</Description>
     </PropertyGroup>
   
@@ -328,8 +329,8 @@
         <EmbeddedResource Remove="Toolkit\KryptonCheckButtonCollectionForm.resx" />
         <EmbeddedResource Remove="Toolkit\PaletteDrawBordersSelector.resx" />
     </ItemGroup>
-    <ItemGroup>
-      <Reference Include="System.Design" />
+    <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
+        <Reference Include="System.Design" />
     </ItemGroup>
     <PropertyGroup>
         <DocumentationFile>..\..\..\Bin\$(Configuration)\Krypton.Toolkit.xml</DocumentationFile>

--- a/Source/Krypton Components/ComponentFactory.Krypton.Workspace/Krypton.Workspace 2019.csproj
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Workspace/Krypton.Workspace 2019.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFrameworks>net40;net45;net451;net452;net46;net461;net462;net47;net471;net472;net48;netcoreapp3.1</TargetFrameworks>
-      <LangVersion>8.0</LangVersion>
+    <TargetFrameworks>net45;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TFMs)' == 'all'">net40;net45;net451;net452;net46;net461;net462;net47;net471;net472;net48;netcoreapp3.1</TargetFrameworks>
+    <LangVersion>8.0</LangVersion>
     <OutputType>Library</OutputType>
     <RootNamespace>ComponentFactory.Krypton.Workspace</RootNamespace>
     <AssemblyName>Krypton.Workspace</AssemblyName>
@@ -12,7 +13,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PackageId>KryptonToolkitSuiteWorkspaceModule</PackageId>
+    <PackageId>Krypton.Workspace</PackageId>
     <Description>A update to Component factory's krypton toolkit to support .NET Core and the latest .NET 4.x framework. This is the workspace module.</Description>
   </PropertyGroup>
 
@@ -39,7 +40,7 @@
   <ItemGroup>
     <Compile Include="..\ComponentFactory.Krypton.Toolkit\General\GlobalSuppressions.cs" Link="General\GlobalSuppressions.cs" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
     <Reference Include="System.Design" />
   </ItemGroup>
   <PropertyGroup>

--- a/Source/Krypton Components/Directory.Build.props
+++ b/Source/Krypton Components/Directory.Build.props
@@ -3,20 +3,22 @@
   
   <PropertyGroup>
     <!-- common project data -->
-	<Version>$(LibraryVersion)</Version>
+	  <Version>$(LibraryVersion)</Version>
+    <!-- two flavors of TFM are supported : 'all' where the nuget package include all supported tfms. 'lite' with only .net core and .net 4.5 support -->
+    <TFMs Condition="'$(TFMs)' == ''">lite</TFMs>
   </PropertyGroup>
   
   <PropertyGroup>
     <!-- common package data -->
     <PackageProjectUrl>https://github.com/Wagnerp/Krypton-Toolkit-Suite-NET-Core</PackageProjectUrl>
-	<PackageIcon>Square Design 64 x 64 New Green.png</PackageIcon>
-	<Authors>Peter William Wagner &amp; Simon Coghlan</Authors>
-	<PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
-	<PackageTags>Krypton ComponentFactory WinForms Themes Controls DataGrid Ribbon Workspace Tabs .Net Toolkit Core</PackageTags>
-	<PackageReleaseNotes>Get updates here: https://github.com/Wagnerp/Krypton-Toolkit-Suite-NET-Core</PackageReleaseNotes>
+	  <PackageIcon>Square Design 64 x 64 New Green.png</PackageIcon>
+	  <Authors>Peter William Wagner &amp; Simon Coghlan</Authors>
+	  <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
+	  <PackageTags>Krypton ComponentFactory WinForms Themes Controls DataGrid Ribbon Workspace Tabs .Net Toolkit Core</PackageTags>
+	  <PackageReleaseNotes>Get updates here: https://github.com/Wagnerp/Krypton-Toolkit-Suite-NET-Core</PackageReleaseNotes>
   </PropertyGroup>
   
   <ItemGroup>
-	<None Include="../../../Assets/PNG/Square Design/Main Icon/64 x 64/Square Design 64 x 64 New Green.png" Link="Icon.png" Pack="true" PackagePath="" />
+	  <None Include="../../../Assets/PNG/Square Design/Main Icon/64 x 64/Square Design 64 x 64 New Green.png" Link="Icon.png" Pack="true" PackagePath="" />
   </ItemGroup>
 </Project>

--- a/Source/Krypton Components/Directory.Build.targets
+++ b/Source/Krypton Components/Directory.Build.targets
@@ -1,0 +1,20 @@
+<Project>
+    <!-- For reference, not used
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../../'))" />
+    -->
+
+    <PropertyGroup>
+        <PackageId Condition="'$(TFMs)' == 'lite'">$(PackageId).Lite</PackageId>
+        <Description Condition="'$(TFMs)' == 'lite'">
+            $(Description)
+            This package supports only .NET Framework >= 4.5 and .NET Core 3.1.
+            If you require .NET 4.0 support or want to use library fully build against your specific framework version use non-lite package.
+        </Description>
+        <Description Condition="'$(TFMs)' == 'all'">
+            $(Description)
+            This package supports all .NET Framework versions starting .NET 4.0 and .NET Core 3.1.
+            Also, all libraries are included targeting each specific framework version for performance purposes.
+            If you target only .NET Framework >= 4.5 and are not interested in specific framework version, consider using the lite package.
+        </Description>
+    </PropertyGroup>
+</Project>

--- a/build.proj
+++ b/build.proj
@@ -5,8 +5,22 @@
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
 		<Configuration>Release</Configuration>
 	</PropertyGroup>
+
+	<Target Name="Clean">
+		<ItemGroup>
+			<Projects Include="$(RootFolder)\Source\Krypton Components\ComponentFactory.Krypton.*\*.csproj" />
+		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration)" Targets="Clean" />
+	</Target>	
+
+	<Target Name="Restore">
+		<ItemGroup>
+			<Projects Include="$(RootFolder)\Source\Krypton Components\ComponentFactory.Krypton.*\*.csproj" />
+		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
+	</Target>
 	
-	<Target Name="Build">
+	<Target Name="Build" DependsOnTargets="Restore">
 		<ItemGroup>
 			<Projects Include="$(RootFolder)\Source\Krypton Components\ComponentFactory.Krypton.*\*.csproj" />
 		</ItemGroup>
@@ -20,11 +34,12 @@
 		<Delete Files="@(NugetPkgs)" />
 	</Target>
 	
-	<Target Name="Pack" DependsOnTargets="CleanPackages">
+	<Target Name="Pack" DependsOnTargets="CleanPackages;Restore">
 		<ItemGroup>
 			<Projects Include="$(RootFolder)\Source\Krypton Components\ComponentFactory.Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration)" Targets="Pack" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Pack" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Pack" />
 	</Target>
 	
 	<Target Name="Push">

--- a/build.proj
+++ b/build.proj
@@ -24,7 +24,7 @@
 		<ItemGroup>
 			<Projects Include="$(RootFolder)\Source\Krypton Components\ComponentFactory.Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration)" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" />
 	</Target>
 	
 	<Target Name="CleanPackages">
@@ -38,8 +38,13 @@
 		<ItemGroup>
 			<Projects Include="$(RootFolder)\Source\Krypton Components\ComponentFactory.Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Pack" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration)" Targets="Clean" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Restore" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Pack" />
+		
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration)" Targets="Clean" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Restore" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Pack" />
 	</Target>
 	
 	<Target Name="Push">


### PR DESCRIPTION
- [X] renamed package to Krypton.Toolkit.*

This will create package consistent with the assembly name. Fix #21 

- [X] add 'lite' msbuild profile to only build .net45 and .netcoreapp3.1 TFM

This is a solution which could match all points of view.

The Krypton.Toolkit.* package still contains a build for each compatible framework version (from .net 4.0 to 4.8 and .netcoreapp3.1.). It's only build when launching the msbuild "build.cmd Pack" or "publish.cmd".

A new "lite" flavor is created, which only builds .NET 4.5 (chosen arbitrarily, could be discussed) and .NET Core 3.1. When running pack command, a new set of packages are created named with a "lite" prefix and includes only 2 versions of the libraries: .net 4.5 and .netcoreapp3.1. The package size is reduced to 1/7th of the standard package size.

- [x] set default VS build to 'lite'

For performance purposes, default builds only targets .net45 et .netcoreapp3.1. It will provide a more pleasant experience when using visual studio: builds will be a lot quicker and vs project dropdown will not include all target framework flavors
 
- [x] default to create package for full and lite TFMs