### PR TITLE
Changed Separator cursor to built-in instead of serialized

### DIFF
--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controller/SeparatorController.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controller/SeparatorController.cs
@@ -907,8 +907,8 @@ namespace ComponentFactory.Krypton.Toolkit
 
         #region Static Fields
         private static readonly Point _nullPoint = new Point(-1, -1);
-        private static readonly Cursor _cursorHSplit = Properties.Resources.SplitHorizontal;
-        private static readonly Cursor _cursorVSplit = Properties.Resources.SplitVertical;
+        private static readonly Cursor _cursorHSplit = Cursors.HSplit;
+        private static readonly Cursor _cursorVSplit = Cursors.VSplit;
         private static readonly Cursor _cursorHMove = Cursors.SizeNS;
         private static readonly Cursor _cursorVMove = Cursors.SizeWE;
         #endregion


### PR DESCRIPTION
Hello,

on mouse-over on the horizontal or vertical Separator, .NET Core application crashes with the following exception:

`SerializationException: Type 'System.Windows.Forms.Cursor' in Assembly 'System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089' is not marked as serializable.`

The reason is because the separator cursors are serialized in resources, however one of the breaking changes in .NET Core is that the [SerializableAttribute has been removed from System.Windows.Forms.Cursor type](https://docs.microsoft.com/en-us/dotnet/core/compatibility/fx-core#serializableattribute-removed-from-some-windows-forms-types).

This PR provides a fix by using the built-in Cursors.HSplit and Cursors.VSplit cursors instead.