### PR TITLE
fix #38

### DIFF
--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/View Base/ViewComposite.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/View Base/ViewComposite.cs
@@ -44,14 +44,17 @@ namespace ComponentFactory.Krypton.Toolkit
         protected override void Dispose(bool disposing)
         {
             // Dispose of all child views
-            while (Count > 0)
+            if (disposing)
             {
-                this[0].Dispose();
-                RemoveAt(0);
+                while (Count > 0)
+                {
+                    this[0].Dispose();
+                    RemoveAt(0);
+                }
+
+                _views.Clear();
             }
 
-            _views.Clear();
-            
             // Must call base class to finish disposing
             base.Dispose(disposing);
         }


### PR DESCRIPTION
`void Dispose()` code should always respect the parameter value of `disposing` before calling other Dispose() methods.